### PR TITLE
Fix the package on Julia 1.0, where the `Base.Experimental` submodule does not exist

### DIFF
--- a/src/LazilyInitializedFields.jl
+++ b/src/LazilyInitializedFields.jl
@@ -95,7 +95,7 @@ struct UninitializedFieldException <: Exception
 end
 function Base.showerror(io::IO, err::UninitializedFieldException)
     print(io, "field `", err.s, "` in struct of type `$(err.T)` is not initialized")
-    @static if isdefined(Base.Experimental, :show_error_hints)
+    @static if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :show_error_hints)
         Base.Experimental.show_error_hints(io, err)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,7 +71,7 @@ end
     @test_throws ErrorException m.b = 2
 
     @testset "Experimental" begin
-        @static if isdefined(Base.Experimental, :register_error_hint)
+        @static if isdefined(Base, :Experimental) && isdefined(Base.Experimental, :register_error_hint)
             @lazy struct FooExperimental
                 @lazy a::Int
                 @lazy b::Int


### PR DESCRIPTION
This fixes a bug on Julia 1.0 that I introduced in #9.