### PR TITLE
Make the `islazyfield` function part of the public API

### DIFF
--- a/src/LazilyInitializedFields.jl
+++ b/src/LazilyInitializedFields.jl
@@ -3,7 +3,7 @@ A package for handling lazily initialized fields.
 
 ### Exports:
 * macros: `@lazy`, `@init!`, `@uninit!`, `@isinit`.
-* functions: `init!` `uninit!`, `isinit`.
+* functions: `init!` `uninit!`, `isinit`, `islazyfield`.
 * objects: `uninit`.
 * exceptions: `NonLazyFieldException`, `UninitializedFieldException`, `AlreadyInitializedException`
 
@@ -53,7 +53,7 @@ module LazilyInitializedFields
 
 export @lazy, uninit,
        @init!, @isinit, @uninit!,
-        init!,  isinit,  uninit!,
+        init!,  isinit,  uninit!, islazyfield,
         NonLazyFieldException, UninitializedFieldException, AlreadyInitializedException
 
 


### PR DESCRIPTION
The use case here is that I want to call `isinit(x, :somefield)`, but this will error if `:somefield` is not a lazy field, so I first need to do `islazyfield(typeof(x), :somefield)`.