### PR TITLE
allowed `@lazy` to accept structs with supertypes

### DIFF
--- a/src/LazilyInitializedFields.jl
+++ b/src/LazilyInitializedFields.jl
@@ -286,8 +286,8 @@ function lazy_struct(expr, mod)
     elseif structdef isa Expr && structdef.head === :curly
         structdef.args[1]
     elseif structdef isa Expr && structdef.head === :<:
-        structdef.args[1]
-        structdef.args[2]
+        subtype = structdef.args[1]
+        (subtype isa Symbol) ? subtype : subtype.args[1]
     else
         error("internal error: unhandled expression $expr")
     end

--- a/src/LazilyInitializedFields.jl
+++ b/src/LazilyInitializedFields.jl
@@ -285,6 +285,9 @@ function lazy_struct(expr, mod)
         structdef
     elseif structdef isa Expr && structdef.head === :curly
         structdef.args[1]
+    elseif structdef isa Expr && structdef.head === :<:
+        structdef.args[1]
+        structdef.args[2]
     else
         error("internal error: unhandled expression $expr")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ end
 m = Mut(1, uninit)
 
 abstract type TestType end
+abstract type ParamTestType{T} end
 
 # A utility function that takes in a closure, and returns the exception that is thrown when
 # that closure is run.
@@ -70,6 +71,14 @@ end
     end)
     b = Bar{Int}(1, uninit)
     @test b.a == 1
+    @test_throws UninitializedFieldException b.b
+
+    @test @no_error (@lazy struct Baz{T} <: ParamTestType{T}
+        a::T
+        @lazy b::Vector{T}
+    end)
+    b = Baz{Float64}(1.0, uninit)
+    @test b.a == 1.0
     @test_throws UninitializedFieldException b.b
 
     @test LI.islazyfield.(Foo, (:a, :b, :c, :d, :e)) == (false, true, true, true, false)


### PR DESCRIPTION
Previously, the `@lazy` macro didn't allow for a struct with lazily-initialized fields to have super types. In my case, for instance, I have a statistical model that's estimated once, and which has a common parent type with different classes of models:
```julia
abstract type TimeSeriesModel end
@lazy struct AutoRegressiveModel <: TimeSeriesModel
    data
    @lazy coef
end
```
This throws an error: `LoadError: internal error: unhandled expression struct AutoRegressiveModel <: TimeSeries`.

Continuing with my example above, this change would admit an initialization with just the data, and the coefficients of the model could be estimated some time later.