### PR TITLE
test on 1.11 beta

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,6 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: false
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: false
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           - '1.0' # earliest compatible (according to `Project.toml`)
           - '1.6' # current LTS
           - '1' # latest stable
+          - '~1.11.0-0'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
-using LazilyInitializedFields
-const LI = LazilyInitializedFields
+using Test
 using Documenter
 
-using Test
+using LazilyInitializedFields
+const LI = LazilyInitializedFields
+
 @lazy mutable struct Foo{T}
     a::T
     @lazy b::Int


### PR DESCRIPTION
Coverage off:

1.10:
  21 dependencies successfully precompiled in 42 seconds. 3 already precompiled.
  Doctests: LazilyInitializedFields |    1      1  2.2s
  Total: 51s.

1.11:
    21 dependencies successfully precompiled in 58 seconds. 31 already precompiled.
    Doctests: LazilyInitializedFields |    1      1  3.4s
    Total: 1m 11s

-----------

Coverage on:

1.10:
    21 dependencies successfully precompiled in 22 seconds. 3 already precompiled.
    Doctests: LazilyInitializedFields |    1      1  9.8s
     Total: 39 s

1.11:
    21 dependencies successfully precompiled in 55 seconds. 31 already precompiled.
    Doctests: LazilyInitializedFields |    1      1  24.1s
    Total: 1m 31 s

----------------

Coverage on, load last:

1.10: 
    21 dependencies successfully precompiled in 22 seconds. 3 already precompiled.
    Doctests: LazilyInitializedFields |    1      1  9.7s
    Total: 40s

1.11:
    21 dependencies successfully precompiled in 60 seconds. 31 already precompiled.
    Doctests: LazilyInitializedFields |    1      1  15.9s
    Total: 1m 26s
    
